### PR TITLE
[8.0][hr_worked_days_compute_holiday] Revisi unittest

### DIFF
--- a/hr_worked_days_compute_holiday/tests/test_get_worked_day_lines.py
+++ b/hr_worked_days_compute_holiday/tests/test_get_worked_day_lines.py
@@ -124,7 +124,9 @@ class TestGetWorkedDayLines(TransactionCase):
         vals = {
             'employee_id': employee.id,
             'contract_id': contract.id,
-            'struct_id': struct.id
+            'struct_id': struct.id,
+            'date_from': '2017-02-1',
+            'date_to': '2017-02-28'
         }
         new = self.obj_payslip.create(vals)
         onchange = new.onchange_employee_id(


### PR DESCRIPTION
Revisi unittest untuk tanggal payslip dibuat fix disesuaikan dengan data public holiday yang dibuat pada unittest, sehingga tidak terjadi error.